### PR TITLE
Update Select-DuoAccount

### DIFF
--- a/DuoSecurity/Public/Accounts API/Select-DuoAccount.ps1
+++ b/DuoSecurity/Public/Accounts API/Select-DuoAccount.ps1
@@ -50,6 +50,9 @@ function Select-DuoAccount {
 
     if ($Name) {
         $Account = $script:DuoAccountsList | Where-Object { $_.name -eq $Name }
+        if (@($Account).Count -gt 1) {
+            Write-Error 'More then one account found, use AccountId.' -ErrorAction Stop
+        }
     }
 
     if ($AccountId) {


### PR DESCRIPTION
When there is more than one account with the same name Select-DuoAccount won't work correctly.