### PR TITLE
PowerShell 5 support and pipeline input

### DIFF
--- a/DuoSecurity/DuoSecurity.psd1
+++ b/DuoSecurity/DuoSecurity.psd1
@@ -33,7 +33,7 @@
     Description       = 'Duo Security REST module'
 
     # Minimum version of the PowerShell engine required by this module
-    PowerShellVersion = '7.0'
+    # PowerShellVersion = '7.0'
 
     # Name of the PowerShell host required by this module
     # PowerShellHostName = ''

--- a/DuoSecurity/Private/REST Handler/Invoke-DuoRequest.ps1
+++ b/DuoSecurity/Private/REST Handler/Invoke-DuoRequest.ps1
@@ -202,7 +202,11 @@ function Invoke-DuoRequest {
         Method             = $Method
         Uri                = $UriBuilder.Uri
         Headers            = $Headers
-        SkipHttpErrorCheck = $true
+    }
+
+    if ($PSVersionTable.PSVersion.Major -ge 7) {
+        $RestMethod += @{
+            SkipHttpErrorCheck = $true}
     }
 
     if ($Body) {

--- a/DuoSecurity/Public/Admin API/Users/Register-DuoUser.ps1
+++ b/DuoSecurity/Public/Admin API/Users/Register-DuoUser.ps1
@@ -26,10 +26,12 @@ function Register-DuoUser {
     #>
     [CmdletBinding(SupportsShouldProcess)]
     Param(
-        [Parameter(Mandatory = $true)]
+        [Parameter(ValueFromPipelineByPropertyName = $true, Mandatory = $true)]
+        [ValidateNotNullOrEmpty()]
         [string]$Username,
 
-        [Parameter(Mandatory = $true)]
+        [Parameter(ValueFromPipelineByPropertyName = $true, Mandatory = $true)]
+        [ValidateNotNullOrEmpty()]
         [string]$Email,
 
         [Parameter()]


### PR DESCRIPTION
I made a couple changes to your project here. My shop is all on Powershell 5 and it looks like the only item I could see that was stopping your code from supporting PowerShell 5 was one specific variable being passed to Invoke-RestMethod. I simply added a check for what version of PowerShell is running to append that variable and all testing on my side appears to be working correctly. 

Looking at a few of the other public functions, I added pipeline support to the register-duoUser so it can take pipeline input from get-duoUser. This was tested and appears to be working as expected as well. 

